### PR TITLE
[release=patch] added ability to preset default response factory

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ Manage your form through a small structure for capturing and validating form dat
 [![Build Status](https://travis-ci.com/daniloster/react-form-flow.svg?branch=master)](https://travis-ci.com/daniloster/react-form-flow)
 [![minizipped size](https://flat.badgen.net/bundlephobia/minzip/react-form-flow)](https://bundlephobia.com/result?p=react-form-flow@latest)
 
+## Code Sandbox Examples
 
 [Code Sandbox - With Schema Builder](https://codesandbox.io/s/condescending-cloud-gkdq3)
 
@@ -49,8 +50,6 @@ Installing with yarn
 ```bash
 yarn add react-form-flow
 ```
-
-[Code Sandbox Example](https://codesandbox.io/s/dreamy-bird-mnftf)
 
 ## Documentation
 

--- a/src/SchemaBuilder/SchemaBuilder.js
+++ b/src/SchemaBuilder/SchemaBuilder.js
@@ -27,8 +27,11 @@ function factoryValidation(validationName, isValid, defaultExtraArgs) {
 Validations can be manipulated by get("${validationName}"), purge("${validationName}").`);
   }
 
-  const responseDefault = getResponseFromExtraArgs(defaultExtraArgs);
-  validations[validationName] = ({ response = responseDefault, ...extraArgs } = EMPTY_OBJECT) => {
+  const predefinedResponse = getResponseFromExtraArgs(defaultExtraArgs);
+  validations[validationName] = ({
+    response = predefinedResponse,
+    ...extraArgs
+  } = EMPTY_OBJECT) => {
     const validate = test(validationName, isValid, response);
     return args => validate({ name: validationName, ...args, ...extraArgs });
   };

--- a/src/SchemaBuilder/SchemaBuilder.js
+++ b/src/SchemaBuilder/SchemaBuilder.js
@@ -8,22 +8,29 @@ const validations = {
   test,
 };
 
+export function getResponseFromExtraArgs(defaultExtraArgs) {
+  const { response } = defaultExtraArgs || {};
+  return response;
+}
+
 /**
  * Factories methods to build validations which will be available
  * later in the build schema process
  * @param {string} validationName
  * @param {import('./types').ValidationProcessorChecker} isValid
+ * @param {import('./types').ExtraArguments} defaultExtraArgs
  * @returns {void}
  */
-function factoryValidation(validationName, isValid) {
+function factoryValidation(validationName, isValid, defaultExtraArgs) {
   if (validations[validationName]) {
     throw new Error(`The validation "${validationName}" already exists, you cannot override it.
 Validations can be manipulated by get("${validationName}"), purge("${validationName}").`);
   }
 
-  validations[validationName] = ({ response, ...extraArgs } = EMPTY_OBJECT) => {
+  const responseDefault = getResponseFromExtraArgs(defaultExtraArgs);
+  validations[validationName] = ({ response = responseDefault, ...extraArgs } = EMPTY_OBJECT) => {
     const validate = test(validationName, isValid, response);
-    return args => validate({ ...args, ...extraArgs });
+    return args => validate({ name: validationName, ...args, ...extraArgs });
   };
 }
 

--- a/src/SchemaBuilder/test.js
+++ b/src/SchemaBuilder/test.js
@@ -1,5 +1,5 @@
 function defaultResponse(args, validationName) {
-  return { key: `${args.path}.errors.${validationName}` };
+  return { key: `${args.path}.errors.${validationName}`.replace(/\[\d*\]/g, '') };
 }
 
 export default function test(validationName, isValid, response = defaultResponse) {

--- a/test/SchemaBuilder/SchemaBuilder.spec.js
+++ b/test/SchemaBuilder/SchemaBuilder.spec.js
@@ -1,9 +1,22 @@
 import SchemaBuilder from '../../src/SchemaBuilder'
+import { getResponseFromExtraArgs } from '../../src/SchemaBuilder/SchemaBuilder'
 import { get } from 'mutation-helper'
 
 describe('SchemaBuilder', () => {
   beforeEach(() => {
     SchemaBuilder.purge()
+  })
+
+  describe('getResponseFromExtraArgs handles unset cases', () => {
+    test('if getResponseFromExtraArgs returns undefined to undefined extraArgs', () => {
+      expect(getResponseFromExtraArgs()).toBe(undefined)
+    })
+    test('if getResponseFromExtraArgs returns undefined to empty extraArgs', () => {
+      expect(getResponseFromExtraArgs({ /* empty */ })).toBe(undefined)
+    })
+    test('if getResponseFromExtraArgs returns function to extraArgs within response', () => {
+      expect(getResponseFromExtraArgs({ response: function() {} })).toBeInstanceOf(Function)
+    })
   })
 
   describe('SchemaBuilder allow access to manage validations', () => {
@@ -88,6 +101,7 @@ describe('SchemaBuilder', () => {
           dependencies: [],
           get,
           isValid: true,
+          name: 'string',
           optional: false,
           key: "name.errors.string",
           path: "name",
@@ -101,6 +115,7 @@ describe('SchemaBuilder', () => {
             dependencies:  [],
             get,
             isValid: true,
+            name: 'string',
             optional: false,
             key: "name.errors.string",
             path: "name",
@@ -126,6 +141,7 @@ describe('SchemaBuilder', () => {
           dependencies: [],
           get,
           isValid: true,
+          name: 'string',
           optional: true,
           key: "name.errors.string",
           path: "name",
@@ -137,6 +153,7 @@ describe('SchemaBuilder', () => {
             dependencies:  [],
             get,
             isValid: true,
+            name: 'string',
             optional: true,
             key: "name.errors.string",
             path: "name",


### PR DESCRIPTION
## Description

Added ability to define factory for responses when creating a validation.

## Usage

```js
function defaultMessage({ name, path }) {
  return {
    // removing indexes from paths for array
    key: `myAppContext.${path}.errors.${name}`.replace(/\[\d*\]/g, '')
  }
}

SchemaBuilder.factory('required', isValidFunction, { response: defaultMessage })
```